### PR TITLE
Create setup.cfg

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,2 @@
+[bdist_rpm]
+obsoletes = django-rest-framework-docs


### PR DESCRIPTION
when updating rpm's from django-rest-framework-docs to drfdocs the rpm fails to update because of conflicting files, this obsolets should tell yum/dnf to first remove the old rpm
